### PR TITLE
using Jackson 2.5 and up causes issues when interacting with reculry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: java
+script:
+  - mvn clean test

--- a/LICENSE-2.0.txt
+++ b/LICENSE-2.0.txt
@@ -1,0 +1,203 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2010-2014 Ning, Inc.
+   Copyright 2014-2015 The Billing Project, LLC
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If you wish to specify extra parameters (such as account id and subscription cod
     extraParams.add(String.format("%s=%s", "account%5Baccount_code%5D", "123abc"));
 	String signature = RecurlyJs.getRecurlySignature(String jsPrivateKey, extraParams);
 
-Refer to the [Recurly.js Signature Generation documentation](http://docs.recurly.com/api/recurlyjs/signatures) for more information on the format for building parameters.
+Refer to the [Recurly.js Signature Generation documentation](https://docs.recurly.com/deprecated-api-docs/recurlyjs/signatures) for more information on the format for building parameters.
 
 
 Build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-recurly-java-library
+recurly-java-library [![Build Status](https://travis-ci.org/killbilling/recurly-java-library.svg)](https://travis-ci.org/killbilling/recurly-java-library)
 ====================
+
 
 Java library for Recurly, originally developed for [Kill Bill](http://killbill.io), an open-source subscription management and billing system.
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,8 @@
 <!--
-  ~ Copyright 2010-2012 Ning, Inc.
+  ~ Copyright 2010-2014 Ning, Inc.
+  ~ Copyright 2014-2015 The Billing Project, LLC
   ~
-  ~ Ning licenses this file to you under the Apache License, version 2.0
+  ~ The Billing Project licenses this file to you under the Apache License, version 2.0
   ~ (the "License"); you may not use this file except in compliance with the
   ~ License.  You may obtain a copy of the License at:
   ~

--- a/src/main/java/com/ning/billing/recurly/PaginationUtils.java
+++ b/src/main/java/com/ning/billing/recurly/PaginationUtils.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/RecurlyAPIException.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyAPIException.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -128,7 +128,7 @@ public class RecurlyClient {
     private final String key;
     private final String baseUrl;
     private AsyncHttpClient client;
-    
+
     public RecurlyClient(final String apiKey) {
         this(apiKey, "api");
     }
@@ -383,8 +383,8 @@ public class RecurlyClient {
                       subscriptionUpdate,
                       Subscription.class);
     }
-    
-    
+
+
     /**
      * Update to a particular {@link Subscription}'s notes by it's UUID
      * <p/>
@@ -392,7 +392,7 @@ public class RecurlyClient {
      *
      * @param uuid UUID of the subscription to preview an update for
      * @param subscriptionNotes SubscriptionNotes object
-     * @return Subscription the updated subscription 
+     * @return Subscription the updated subscription
      */
     public Subscription updateSubscriptionNotes(final String uuid, final SubscriptionNotes subscriptionNotes) {
       return doPUT(SubscriptionNotes.SUBSCRIPTION_RESOURCE + "/" + uuid + "/notes",
@@ -536,7 +536,7 @@ public class RecurlyClient {
 
     ///////////////////////////////////////////////////////////////////////////
     // User invoices
-    
+
     /**
      * Lookup an invoice
      * <p/>
@@ -547,7 +547,7 @@ public class RecurlyClient {
      */
     public Invoice getInvoice(final Integer invoiceId) {
         return doGET(Invoices.INVOICES_RESOURCE + "/" + invoiceId, Invoice.class);
-    }    
+    }
 
     /**
      * Lookup an account's invoices
@@ -951,7 +951,7 @@ public class RecurlyClient {
                     try {
                         errors = xmlMapper.readValue(payload, Errors.class);
                     } catch (Exception e) {
-                        // 422 is returned for transaction errors (see http://docs.recurly.com/api/transactions/error-codes)
+                        // 422 is returned for transaction errors (see https://recurly.readme.io/v2.0/page/transaction-errors)
                         // as well as bad input payloads
                         log.debug("Unable to extract error", e);
                         return null;

--- a/src/main/java/com/ning/billing/recurly/RecurlyClient.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyClient.java
@@ -162,7 +162,7 @@ public class RecurlyClient {
 
     /**
      * Create Account
-     * <p/>
+     * <p>
      * Creates a new account. You may optionally include billing information.
      *
      * @param account account object
@@ -174,7 +174,7 @@ public class RecurlyClient {
 
     /**
      * Get Accounts
-     * <p/>
+     * <p>
      * Returns information about all accounts.
      *
      * @return account object on success, null otherwise
@@ -189,7 +189,7 @@ public class RecurlyClient {
 
     /**
      * Get Account
-     * <p/>
+     * <p>
      * Returns information about a single account.
      *
      * @param accountCode recurly account id
@@ -201,7 +201,7 @@ public class RecurlyClient {
 
     /**
      * Update Account
-     * <p/>
+     * <p>
      * Updates an existing account.
      *
      * @param accountCode recurly account id
@@ -214,7 +214,7 @@ public class RecurlyClient {
 
     /**
      * Close Account
-     * <p/>
+     * <p>
      * Marks an account as closed and cancels any active subscriptions. Any saved billing information will also be
      * permanently removed from the account.
      *
@@ -265,7 +265,7 @@ public class RecurlyClient {
 
     /**
      * Create a subscription
-     * <p/>
+     * <p>
      * Creates a subscription for an account.
      *
      * @param subscription Subscription object
@@ -278,7 +278,7 @@ public class RecurlyClient {
 
     /**
      * Preview a subscription
-     * <p/>
+     * <p>
      * Previews a subscription for an account.
      *
      * @param subscription Subscription object
@@ -292,7 +292,7 @@ public class RecurlyClient {
 
     /**
      * Get a particular {@link Subscription} by it's UUID
-     * <p/>
+     * <p>
      * Returns information about a single subscription.
      *
      * @param uuid UUID of the subscription to lookup
@@ -306,7 +306,7 @@ public class RecurlyClient {
 
     /**
      * Cancel a subscription
-     * <p/>
+     * <p>
      * Cancel a subscription so it remains active and then expires at the end of the current bill cycle.
      *
      * @param subscription Subscription object
@@ -319,7 +319,7 @@ public class RecurlyClient {
 
     /**
      * Postpone a subscription
-     * <p/>
+     * <p>
      * postpone a subscription, setting a new renewal date.
      *
      * @param subscription Subscription object
@@ -342,7 +342,7 @@ public class RecurlyClient {
 
     /**
      * Reactivating a canceled subscription
-     * <p/>
+     * <p>
      * Reactivate a canceled subscription so it renews at the end of the current bill cycle.
      *
      * @param subscription Subscription object
@@ -355,7 +355,7 @@ public class RecurlyClient {
 
     /**
      * Update a particular {@link Subscription} by it's UUID
-     * <p/>
+     * <p>
      * Returns information about a single subscription.
      *
      * @param uuid               UUID of the subscription to update
@@ -371,7 +371,7 @@ public class RecurlyClient {
 
     /**
      * Preview an update to a particular {@link Subscription} by it's UUID
-     * <p/>
+     * <p>
      * Returns information about a single subscription.
      *
      * @param uuid UUID of the subscription to preview an update for
@@ -387,7 +387,7 @@ public class RecurlyClient {
 
     /**
      * Update to a particular {@link Subscription}'s notes by it's UUID
-     * <p/>
+     * <p>
      * Returns information about a single subscription.
      *
      * @param uuid UUID of the subscription to preview an update for
@@ -401,7 +401,7 @@ public class RecurlyClient {
 
     /**
      * Get the subscriptions for an {@link Account}.
-     * <p/>
+     * <p>
      * Returns information about a single {@link Account}.
      *
      * @param accountCode recurly account id
@@ -416,7 +416,7 @@ public class RecurlyClient {
 
     /**
      * Get the subscriptions for an account.
-     * <p/>
+     * <p>
      * Returns information about a single account.
      *
      * @param accountCode recurly account id
@@ -436,14 +436,14 @@ public class RecurlyClient {
 
     /**
      * Update an account's billing info
-     * <p/>
+     * <p>
      * When new or updated credit card information is updated, the billing information is only saved if the credit card
      * is valid. If the account has a past due invoice, the outstanding balance will be collected to validate the
      * billing information.
-     * <p/>
+     * <p>
      * If the account does not exist before the API request, the account will be created if the billing information
      * is valid.
-     * <p/>
+     * <p>
      * Please note: this API end-point may be used to import billing information without security codes (CVV).
      * Recurly recommends requiring CVV from your customers when collecting new or updated billing information.
      *
@@ -460,7 +460,7 @@ public class RecurlyClient {
 
     /**
      * Lookup an account's billing info
-     * <p/>
+     * <p>
      * Returns only the account's current billing information.
      *
      * @param accountCode recurly account id
@@ -473,7 +473,7 @@ public class RecurlyClient {
 
     /**
      * Clear an account's billing info
-     * <p/>
+     * <p>
      * You may remove any stored billing information for an account. If the account has a subscription, the renewal will
      * go into past due unless you update the billing info before the renewal occurs
      *
@@ -488,7 +488,7 @@ public class RecurlyClient {
 
     /**
      * Lookup an account's transactions history
-     * <p/>
+     * <p>
      * Returns the account's transaction history
      *
      * @param accountCode recurly account id
@@ -539,7 +539,7 @@ public class RecurlyClient {
 
     /**
      * Lookup an invoice
-     * <p/>
+     * <p>
      * Returns the invoice
      *
      * @param invoiceId Recurly Invoice ID
@@ -551,7 +551,7 @@ public class RecurlyClient {
 
     /**
      * Lookup an account's invoices
-     * <p/>
+     * <p>
      * Returns the account's invoices
      *
      * @param accountCode recurly account id
@@ -564,7 +564,7 @@ public class RecurlyClient {
 
     /**
      * Post an invoice: invoice pending charges on an account
-     * <p/>
+     * <p>
      * Returns an invoice
      *
      * @param accountCode
@@ -606,7 +606,7 @@ public class RecurlyClient {
 
     /**
      * Create a Plan's info
-     * <p/>
+     * <p>
      *
      * @param plan The plan to create on recurly
      * @return the plan object as identified by the passed in ID
@@ -617,7 +617,7 @@ public class RecurlyClient {
 
     /**
      * Get a Plan's details
-     * <p/>
+     * <p>
      *
      * @param planCode recurly id of plan
      * @return the plan object as identified by the passed in ID
@@ -628,7 +628,7 @@ public class RecurlyClient {
 
     /**
      * Return all the plans
-     * <p/>
+     * <p>
      *
      * @return the plan object as identified by the passed in ID
      */
@@ -638,7 +638,7 @@ public class RecurlyClient {
 
     /**
      * Deletes a {@link Plan}
-     * <p/>
+     * <p>
      *
      * @param planCode The {@link Plan} object to delete.
      */
@@ -652,7 +652,7 @@ public class RecurlyClient {
 
     /**
      * Create an AddOn to a Plan
-     * <p/>
+     * <p>
      *
      * @param planCode The planCode of the {@link Plan } to create within recurly
      * @param addOn    The {@link AddOn} to create within recurly
@@ -668,7 +668,7 @@ public class RecurlyClient {
 
     /**
      * Get an AddOn's details
-     * <p/>
+     * <p>
      *
      * @param addOnCode recurly id of {@link AddOn}
      * @param planCode  recurly id of {@link Plan}
@@ -685,7 +685,7 @@ public class RecurlyClient {
 
     /**
      * Return all the {@link AddOn} for a {@link Plan}
-     * <p/>
+     * <p>
      *
      * @return the {@link AddOn} objects as identified by the passed plan ID
      */
@@ -698,7 +698,7 @@ public class RecurlyClient {
 
     /**
      * Deletes a {@link AddOn} for a Plan
-     * <p/>
+     * <p>
      *
      * @param planCode  The {@link Plan} object.
      * @param addOnCode The {@link AddOn} object to delete.
@@ -716,7 +716,7 @@ public class RecurlyClient {
 
     /**
      * Create a {@link Coupon}
-     * <p/>
+     * <p>
      *
      * @param coupon The coupon to create on recurly
      * @return the {@link Coupon} object
@@ -727,7 +727,7 @@ public class RecurlyClient {
 
     /**
      * Get a Coupon
-     * <p/>
+     * <p>
      *
      * @param couponCode The code for the {@link Coupon}
      * @return The {@link Coupon} object as identified by the passed in code
@@ -738,7 +738,7 @@ public class RecurlyClient {
 
     /**
      * Delete a {@link Coupon}
-     * <p/>
+     * <p>
      *
      * @param couponCode The code for the {@link Coupon}
      */
@@ -798,7 +798,7 @@ public class RecurlyClient {
 
     /**
      * Fetch Subscription
-     * <p/>
+     * <p>
      * Returns subscription from a recurly.js token.
      *
      * @param recurlyToken token given by recurly.js
@@ -810,7 +810,7 @@ public class RecurlyClient {
 
     /**
      * Fetch BillingInfo
-     * <p/>
+     * <p>
      * Returns billing info from a recurly.js token.
      *
      * @param recurlyToken token given by recurly.js
@@ -822,7 +822,7 @@ public class RecurlyClient {
 
     /**
      * Fetch Invoice
-     * <p/>
+     * <p>
      * Returns invoice from a recurly.js token.
      *
      * @param recurlyToken token given by recurly.js

--- a/src/main/java/com/ning/billing/recurly/RecurlyJs.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyJs.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/RecurlyJs.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyJs.java
@@ -41,7 +41,7 @@ public class RecurlyJs {
 
     /**
      * Get Recurly.js Signature
-     * See spec here: http://docs.recurly.com/api/recurlyjs/signatures
+     * See spec here: https://docs.recurly.com/deprecated-api-docs/recurlyjs/signatures
      * <p/>
      * Returns a signature key for use with recurly.js BuildSubscriptionForm.
      *
@@ -54,7 +54,7 @@ public class RecurlyJs {
 
     /**
      * Get Recurly.js Signature
-     * See spec here: http://docs.recurly.com/api/recurlyjs/signatures
+     * See spec here: https://docs.recurly.com/deprecated-api-docs/recurlyjs/signatures
      * <p/>
      * Returns a signature key for use with recurly.js BuildSubscriptionForm.
      *
@@ -70,7 +70,7 @@ public class RecurlyJs {
 
     /**
      * Get Recurly.js Signature with extra parameter strings in the format "[param]=[value]"
-     * See spec here: http://docs.recurly.com/api/recurlyjs/signatures
+     * See spec here: https://docs.recurly.com/deprecated-api-docs/recurlyjs/signatures
      * <p/>
      * Returns a signature key for use with recurly.js BuildSubscriptionForm.
      *

--- a/src/main/java/com/ning/billing/recurly/RecurlyJs.java
+++ b/src/main/java/com/ning/billing/recurly/RecurlyJs.java
@@ -42,7 +42,7 @@ public class RecurlyJs {
     /**
      * Get Recurly.js Signature
      * See spec here: https://docs.recurly.com/deprecated-api-docs/recurlyjs/signatures
-     * <p/>
+     * <p>
      * Returns a signature key for use with recurly.js BuildSubscriptionForm.
      *
      * @param privateJsKey recurly.js private key
@@ -55,7 +55,7 @@ public class RecurlyJs {
     /**
      * Get Recurly.js Signature
      * See spec here: https://docs.recurly.com/deprecated-api-docs/recurlyjs/signatures
-     * <p/>
+     * <p>
      * Returns a signature key for use with recurly.js BuildSubscriptionForm.
      *
      * @param privateJsKey recurly.js private key
@@ -71,7 +71,7 @@ public class RecurlyJs {
     /**
      * Get Recurly.js Signature with extra parameter strings in the format "[param]=[value]"
      * See spec here: https://docs.recurly.com/deprecated-api-docs/recurlyjs/signatures
-     * <p/>
+     * <p>
      * Returns a signature key for use with recurly.js BuildSubscriptionForm.
      *
      * @param privateJsKey recurly.js private key
@@ -92,7 +92,7 @@ public class RecurlyJs {
 
     /**
      * HMAC-SHA1 Hash Generator - Helper method
-     * <p/>
+     * <p>
      * Returns a signature key for use with recurly.js BuildSubscriptionForm.
      *
      * @param privateJsKey recurly.js private key

--- a/src/main/java/com/ning/billing/recurly/TransactionErrorException.java
+++ b/src/main/java/com/ning/billing/recurly/TransactionErrorException.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/AbstractAddOn.java
+++ b/src/main/java/com/ning/billing/recurly/model/AbstractAddOn.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/AbstractSubscription.java
+++ b/src/main/java/com/ning/billing/recurly/model/AbstractSubscription.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/AbstractTransaction.java
+++ b/src/main/java/com/ning/billing/recurly/model/AbstractTransaction.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/Account.java
+++ b/src/main/java/com/ning/billing/recurly/model/Account.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/Accounts.java
+++ b/src/main/java/com/ning/billing/recurly/model/Accounts.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/AddOn.java
+++ b/src/main/java/com/ning/billing/recurly/model/AddOn.java
@@ -1,10 +1,10 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
- * Copyright 2015 Pierre-Alexandre Meyer
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Pierre-Alexandre Meyer licenses this file to you under the Apache License,
- * version 2.0 (the "License"); you may not use this file except in compliance
- * with the License. You may obtain a copy of the License at:
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
  *
  *    http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/main/java/com/ning/billing/recurly/model/AddOns.java
+++ b/src/main/java/com/ning/billing/recurly/model/AddOns.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/Address.java
+++ b/src/main/java/com/ning/billing/recurly/model/Address.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/Adjustment.java
+++ b/src/main/java/com/ning/billing/recurly/model/Adjustment.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/Adjustments.java
+++ b/src/main/java/com/ning/billing/recurly/model/Adjustments.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/BillingInfo.java
+++ b/src/main/java/com/ning/billing/recurly/model/BillingInfo.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/BillingInfo.java
+++ b/src/main/java/com/ning/billing/recurly/model/BillingInfo.java
@@ -96,7 +96,7 @@ public class BillingInfo extends RecurlyObject {
 
     /**
      * Account object associated to this BillingInfo
-     * <p/>
+     * <p>
      * Note: when fetching a BillingInfo object from Recurly, the account object is not guaranteed to be populated.
      *
      * @return account object

--- a/src/main/java/com/ning/billing/recurly/model/Coupon.java
+++ b/src/main/java/com/ning/billing/recurly/model/Coupon.java
@@ -1,10 +1,10 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
- * Copyright 2015 Pierre-Alexandre Meyer
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Pierre-Alexandre Meyer licenses this file to you under the Apache License,
- * version 2.0 (the "License"); you may not use this file except in compliance
- * with the License. You may obtain a copy of the License at:
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
  *
  *    http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/main/java/com/ning/billing/recurly/model/Coupons.java
+++ b/src/main/java/com/ning/billing/recurly/model/Coupons.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/Errors.java
+++ b/src/main/java/com/ning/billing/recurly/model/Errors.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/Invoice.java
+++ b/src/main/java/com/ning/billing/recurly/model/Invoice.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/Invoices.java
+++ b/src/main/java/com/ning/billing/recurly/model/Invoices.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/LineItem.java
+++ b/src/main/java/com/ning/billing/recurly/model/LineItem.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/Plan.java
+++ b/src/main/java/com/ning/billing/recurly/model/Plan.java
@@ -1,10 +1,10 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
- * Copyright 2015 Pierre-Alexandre Meyer
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Pierre-Alexandre Meyer licenses this file to you under the Apache License,
- * version 2.0 (the "License"); you may not use this file except in compliance
- * with the License. You may obtain a copy of the License at:
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
  *
  *    http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/main/java/com/ning/billing/recurly/model/Plans.java
+++ b/src/main/java/com/ning/billing/recurly/model/Plans.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/RecurlyAPIError.java
+++ b/src/main/java/com/ning/billing/recurly/model/RecurlyAPIError.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/RecurlyError.java
+++ b/src/main/java/com/ning/billing/recurly/model/RecurlyError.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/RecurlyErrors.java
+++ b/src/main/java/com/ning/billing/recurly/model/RecurlyErrors.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/RecurlyObject.java
+++ b/src/main/java/com/ning/billing/recurly/model/RecurlyObject.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/RecurlyObject.java
+++ b/src/main/java/com/ning/billing/recurly/model/RecurlyObject.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import javax.xml.bind.annotation.XmlTransient;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import org.joda.time.DateTime;
 
 import com.ning.billing.recurly.RecurlyClient;
@@ -75,6 +76,7 @@ public abstract class RecurlyObject {
         xmlMapper.setAnnotationIntrospector(pair);
         xmlMapper.registerModule(new JodaModule());
         xmlMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        xmlMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
 
         final SimpleModule m = new SimpleModule("module", new Version(1, 0, 0, null, null, null));
         m.addSerializer(Accounts.class, new RecurlyObjectsSerializer<Accounts, Account>(Accounts.class, "account"));

--- a/src/main/java/com/ning/billing/recurly/model/RecurlyObjects.java
+++ b/src/main/java/com/ning/billing/recurly/model/RecurlyObjects.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/RecurlyUnitCurrency.java
+++ b/src/main/java/com/ning/billing/recurly/model/RecurlyUnitCurrency.java
@@ -1,10 +1,10 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2015 Pierre-Alexandre Meyer
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Pierre-Alexandre Meyer licenses this file to you under the Apache License,
- * version 2.0 (the "License"); you may not use this file except in compliance
- * with the License. You may obtain a copy of the License at:
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
  *
  *    http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/main/java/com/ning/billing/recurly/model/Redemption.java
+++ b/src/main/java/com/ning/billing/recurly/model/Redemption.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/RefundOption.java
+++ b/src/main/java/com/ning/billing/recurly/model/RefundOption.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/Subscription.java
+++ b/src/main/java/com/ning/billing/recurly/model/Subscription.java
@@ -1,10 +1,10 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2015 Pierre-Alexandre Meyer
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Pierre-Alexandre Meyer licenses this file to you under the Apache License,
- * version 2.0 (the "License"); you may not use this file except in compliance
- * with the License. You may obtain a copy of the License at:
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
  *
  *    http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/main/java/com/ning/billing/recurly/model/SubscriptionAddOn.java
+++ b/src/main/java/com/ning/billing/recurly/model/SubscriptionAddOn.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/SubscriptionAddOns.java
+++ b/src/main/java/com/ning/billing/recurly/model/SubscriptionAddOns.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/SubscriptionNotes.java
+++ b/src/main/java/com/ning/billing/recurly/model/SubscriptionNotes.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/SubscriptionUpdate.java
+++ b/src/main/java/com/ning/billing/recurly/model/SubscriptionUpdate.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/SubscriptionUpdate.java
+++ b/src/main/java/com/ning/billing/recurly/model/SubscriptionUpdate.java
@@ -21,7 +21,7 @@ import javax.xml.bind.annotation.XmlElement;
 
 /**
  * Subscription object for update calls.
- * <p/>
+ * <p>
  * The timeframe parameter is specific to the update.
  */
 public class SubscriptionUpdate extends AbstractSubscription {

--- a/src/main/java/com/ning/billing/recurly/model/Subscriptions.java
+++ b/src/main/java/com/ning/billing/recurly/model/Subscriptions.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/Transaction.java
+++ b/src/main/java/com/ning/billing/recurly/model/Transaction.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/TransactionDetails.java
+++ b/src/main/java/com/ning/billing/recurly/model/TransactionDetails.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/TransactionError.java
+++ b/src/main/java/com/ning/billing/recurly/model/TransactionError.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/Transactions.java
+++ b/src/main/java/com/ning/billing/recurly/model/Transactions.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/jackson/RecurlyObjectsSerializer.java
+++ b/src/main/java/com/ning/billing/recurly/model/jackson/RecurlyObjectsSerializer.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/jackson/RecurlyXmlSerializerProvider.java
+++ b/src/main/java/com/ning/billing/recurly/model/jackson/RecurlyXmlSerializerProvider.java
@@ -1,9 +1,10 @@
 /*
- * Copyright 2015 Pierre-Alexandre Meyer
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Pierre-Alexandre Meyer licenses this file to you under the Apache License,
- * version 2.0 (the "License"); you may not use this file except in compliance
- * with the License. You may obtain a copy of the License at:
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
  *
  *    http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/main/java/com/ning/billing/recurly/model/push/Notification.java
+++ b/src/main/java/com/ning/billing/recurly/model/push/Notification.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/push/Notification.java
+++ b/src/main/java/com/ning/billing/recurly/model/push/Notification.java
@@ -39,7 +39,7 @@ public abstract class Notification extends RecurlyObject {
         FailedPaymentNotification(com.ning.billing.recurly.model.push.payment.FailedPaymentNotification.class),
         SuccessfulPaymentNotification(com.ning.billing.recurly.model.push.payment.SuccessfulPaymentNotification.class),
         SuccessfulRefundNotification(com.ning.billing.recurly.model.push.payment.SuccessfulRefundNotification.class),
-        VoidedPaymentNotification(com.ning.billing.recurly.model.push.payment.VoidedPaymentNotification.class),
+        VoidPaymentNotification(com.ning.billing.recurly.model.push.payment.VoidPaymentNotification.class),
         CanceledSubscriptionNotification(com.ning.billing.recurly.model.push.subscription.CanceledSubscriptionNotification.class),
         ExpiredSubscriptionNotification(com.ning.billing.recurly.model.push.subscription.ExpiredSubscriptionNotification.class),
         NewSubscriptionNotification(com.ning.billing.recurly.model.push.subscription.NewSubscriptionNotification.class),

--- a/src/main/java/com/ning/billing/recurly/model/push/account/AccountNotification.java
+++ b/src/main/java/com/ning/billing/recurly/model/push/account/AccountNotification.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/push/account/BillingInfoUpdatedNotification.java
+++ b/src/main/java/com/ning/billing/recurly/model/push/account/BillingInfoUpdatedNotification.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/push/account/CanceledAccountNotification.java
+++ b/src/main/java/com/ning/billing/recurly/model/push/account/CanceledAccountNotification.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/push/account/NewAccountNotification.java
+++ b/src/main/java/com/ning/billing/recurly/model/push/account/NewAccountNotification.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/push/payment/FailedPaymentNotification.java
+++ b/src/main/java/com/ning/billing/recurly/model/push/payment/FailedPaymentNotification.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/push/payment/PaymentNotification.java
+++ b/src/main/java/com/ning/billing/recurly/model/push/payment/PaymentNotification.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/push/payment/PushTransaction.java
+++ b/src/main/java/com/ning/billing/recurly/model/push/payment/PushTransaction.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/push/payment/SuccessfulPaymentNotification.java
+++ b/src/main/java/com/ning/billing/recurly/model/push/payment/SuccessfulPaymentNotification.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/push/payment/SuccessfulRefundNotification.java
+++ b/src/main/java/com/ning/billing/recurly/model/push/payment/SuccessfulRefundNotification.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/push/payment/VoidPaymentNotification.java
+++ b/src/main/java/com/ning/billing/recurly/model/push/payment/VoidPaymentNotification.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/push/payment/VoidPaymentNotification.java
+++ b/src/main/java/com/ning/billing/recurly/model/push/payment/VoidPaymentNotification.java
@@ -19,9 +19,9 @@ package com.ning.billing.recurly.model.push.payment;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "void_payment_notification")
-public class VoidedPaymentNotification extends PaymentNotification {
+public class VoidPaymentNotification extends PaymentNotification {
 
-    public static VoidedPaymentNotification read(final String payload) {
-        return read(payload, VoidedPaymentNotification.class);
+    public static VoidPaymentNotification read(final String payload) {
+        return read(payload, VoidPaymentNotification.class);
     }
 }

--- a/src/main/java/com/ning/billing/recurly/model/push/subscription/CanceledSubscriptionNotification.java
+++ b/src/main/java/com/ning/billing/recurly/model/push/subscription/CanceledSubscriptionNotification.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/push/subscription/ExpiredSubscriptionNotification.java
+++ b/src/main/java/com/ning/billing/recurly/model/push/subscription/ExpiredSubscriptionNotification.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/push/subscription/NewSubscriptionNotification.java
+++ b/src/main/java/com/ning/billing/recurly/model/push/subscription/NewSubscriptionNotification.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/push/subscription/PushSubscription.java
+++ b/src/main/java/com/ning/billing/recurly/model/push/subscription/PushSubscription.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/push/subscription/ReactivatedAccountNotification.java
+++ b/src/main/java/com/ning/billing/recurly/model/push/subscription/ReactivatedAccountNotification.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/push/subscription/RenewedSubscriptionNotification.java
+++ b/src/main/java/com/ning/billing/recurly/model/push/subscription/RenewedSubscriptionNotification.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/push/subscription/SubscriptionNotification.java
+++ b/src/main/java/com/ning/billing/recurly/model/push/subscription/SubscriptionNotification.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/main/java/com/ning/billing/recurly/model/push/subscription/UpdatedSubscriptionNotification.java
+++ b/src/main/java/com/ning/billing/recurly/model/push/subscription/UpdatedSubscriptionNotification.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/test/java/com/ning/billing/recurly/TestPaginationUtils.java
+++ b/src/test/java/com/ning/billing/recurly/TestPaginationUtils.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
+++ b/src/test/java/com/ning/billing/recurly/TestRecurlyClient.java
@@ -1,10 +1,10 @@
 /*
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2015 Pierre-Alexandre Meyer
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Pierre-Alexandre Meyer licenses this file to you under the Apache License,
- * version 2.0 (the "License"); you may not use this file except in compliance
- * with the License. You may obtain a copy of the License at:
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
  *
  *    http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/test/java/com/ning/billing/recurly/TestRecurlyClientUserAgent.java
+++ b/src/test/java/com/ning/billing/recurly/TestRecurlyClientUserAgent.java
@@ -1,8 +1,9 @@
 /*
- * Copyright 2014 Pierre-Alexandre Meyer
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Pierre-Alexandre Meyer licenses this file to you under the Apache License,
- * version 2.0 (the "License"); you may not use this file except in compliance with the
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *
  *    http://www.apache.org/licenses/LICENSE-2.0

--- a/src/test/java/com/ning/billing/recurly/TestRecurlyJs.java
+++ b/src/test/java/com/ning/billing/recurly/TestRecurlyJs.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/test/java/com/ning/billing/recurly/TestUtils.java
+++ b/src/test/java/com/ning/billing/recurly/TestUtils.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/test/java/com/ning/billing/recurly/model/TestAccount.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestAccount.java
@@ -25,7 +25,7 @@ public class TestAccount extends TestModelBase {
 
     @Test(groups = "fast")
     public void testSerialization() throws Exception {
-        // See http://docs.recurly.com/api/accounts
+        // See https://dev.recurly.com/docs/list-accounts
         final String accountData = "<account href=\"https://api.recurly.com/v2/accounts/1\">\n" +
                                    "  <adjustments href=\"https://api.recurly.com/v2/accounts/1/adjustments\"/>\n" +
                                    "  <billing_info href=\"https://api.recurly.com/v2/accounts/1/billing_info\"/>\n" +

--- a/src/test/java/com/ning/billing/recurly/model/TestAccount.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestAccount.java
@@ -1,11 +1,10 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2015 Pierre-Alexandre Meyer
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Pierre-Alexandre Meyer licenses this file to you under the Apache License,
- * version 2.0 (the "License"); you may not use this file except in compliance
- * with the License. You may obtain a copy of the License at:
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
  *
  *    http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/test/java/com/ning/billing/recurly/model/TestAccounts.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestAccounts.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/test/java/com/ning/billing/recurly/model/TestAccounts.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestAccounts.java
@@ -25,7 +25,7 @@ public class TestAccounts extends TestModelBase {
 
     @Test(groups = "fast")
     public void testDeserialization() throws Exception {
-        // See http://docs.recurly.com/api/accounts
+        // See https://dev.recurly.com/docs/list-accounts
         final String accountsData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                                     "<accounts type=\"array\">\n" +
                                     "  <account href=\"https://api.recurly.com/v2/accounts/1\">\n" +

--- a/src/test/java/com/ning/billing/recurly/model/TestAddOns.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestAddOns.java
@@ -25,7 +25,7 @@ public class TestAddOns extends TestModelBase {
 
     @Test(groups = "fast")
     public void testDeserialization() throws Exception {
-        // See http://docs.recurly.com/api/plans/add-ons
+        // See https://dev.recurly.com/docs/list-add-ons-for-a-plan
         final String addOnsData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                                   "<add_ons type=\"array\">\n" +
                                   "  <add_on href=\"https://your-subdomain.recurly.com/v2/plans/gold/add_ons/ipaddresses\">\n" +

--- a/src/test/java/com/ning/billing/recurly/model/TestAddOns.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestAddOns.java
@@ -1,11 +1,10 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
  * Copyright 2010-2014 Ning, Inc.
- * Copyright 2015 Pierre-Alexandre Meyer
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Pierre-Alexandre Meyer licenses this file to you under the Apache License,
- * version 2.0 (the "License"); you may not use this file except in compliance
- * with the License. You may obtain a copy of the License at:
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
  *
  *    http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/test/java/com/ning/billing/recurly/model/TestAdjustements.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestAdjustements.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/test/java/com/ning/billing/recurly/model/TestAdjustements.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestAdjustements.java
@@ -25,7 +25,7 @@ public class TestAdjustements extends TestModelBase {
 
     @Test(groups = "fast")
     public void testDeserialization() throws Exception {
-        // See http://docs.recurly.com/api/adjustments
+        // See https://dev.recurly.com/docs/list-an-accounts-adjustments
         final String adjustmentsData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                                        "<adjustments type=\"array\">\n" +
                                        "  <adjustment type=\"credit\" href=\"https://api.recurly.com/v2/adjustments/626db120a84102b1809909071c701c60\">\n" +

--- a/src/test/java/com/ning/billing/recurly/model/TestAdjustment.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestAdjustment.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/test/java/com/ning/billing/recurly/model/TestAdjustment.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestAdjustment.java
@@ -25,7 +25,7 @@ public class TestAdjustment extends TestModelBase {
 
     @Test(groups = "fast")
     public void testSerialization() throws Exception {
-        // See http://docs.recurly.com/api/adjustments
+        // See https://dev.recurly.com/docs/list-an-accounts-adjustments
         final String adjustmentData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                                       "<adjustment type=\"credit\" href=\"https://api.recurly.com/v2/adjustments/626db120a84102b1809909071c701c60\">\n" +
                                       "  <account href=\"https://api.recurly.com/v2/accounts/1\"/>\n" +

--- a/src/test/java/com/ning/billing/recurly/model/TestBillingInfo.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestBillingInfo.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/test/java/com/ning/billing/recurly/model/TestCoupon.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestCoupon.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/test/java/com/ning/billing/recurly/model/TestCoupon.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestCoupon.java
@@ -26,7 +26,7 @@ public class TestCoupon extends TestModelBase {
 
     @Test(groups = "fast")
     public void testDeserializationPercent() throws Exception {
-        // See http://docs.recurly.com/api/coupons
+        // See https://dev.recurly.com/docs/list-active-coupons
         final String couponData =
                 "<coupon href=\"https://api.recurly.com/v2/coupons/f8028\">\n" +
                 "  <redemptions href=\"https://api.recurly.com/v2/coupons/f8028/redemptions\"/>\n" +
@@ -64,7 +64,7 @@ public class TestCoupon extends TestModelBase {
 
     @Test(groups = "fast", description = "https://github.com/killbilling/recurly-java-library/issues/57")
     public void testDeserializationDollars() throws Exception {
-        // See http://docs.recurly.com/api/coupons
+        // See https://dev.recurly.com/docs/list-active-coupons
         final String couponData =
                 "<coupon href=\"https://api.recurly.com/v2/coupons/f8028\">\n" +
                 "  <redemptions href=\"https://api.recurly.com/v2/coupons/f8028/redemptions\"/>\n" +

--- a/src/test/java/com/ning/billing/recurly/model/TestCoupons.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestCoupons.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/test/java/com/ning/billing/recurly/model/TestCoupons.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestCoupons.java
@@ -24,7 +24,7 @@ public class TestCoupons extends TestModelBase {
 
     @Test(groups = "fast")
     public void testDeserialization() throws Exception {
-        // See http://docs.recurly.com/api/accounts
+        // See https://dev.recurly.com/docs/list-accounts
         final String accountsData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                                     "<coupons type=\"array\">\n" +
                                     "  <coupon href=\"https://api.recurly.com/v2/coupons/cdeb2\">\n" +

--- a/src/test/java/com/ning/billing/recurly/model/TestErrors.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestErrors.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/test/java/com/ning/billing/recurly/model/TestInvoice.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestInvoice.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/test/java/com/ning/billing/recurly/model/TestInvoice.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestInvoice.java
@@ -25,7 +25,7 @@ public class TestInvoice extends TestModelBase {
 
     @Test(groups = "fast")
     public void testDeserialization() throws Exception {
-        // See http://docs.recurly.com/api/invoices
+        // See https://dev.recurly.com/docs/list-invoices
         final String invoiceData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
                                    + "<invoice href=\"https://api.recurly.com/v2/invoices/e3f0a9e084a2468480d00ee61b090d4d\">\n"
                                    + "  <account href=\"https://api.recurly.com/v2/accounts/1\"/>\n"

--- a/src/test/java/com/ning/billing/recurly/model/TestInvoices.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestInvoices.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/test/java/com/ning/billing/recurly/model/TestInvoices.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestInvoices.java
@@ -25,7 +25,7 @@ public class TestInvoices extends TestModelBase {
 
     @Test(groups = "fast")
     public void testDeserialization() throws Exception {
-        // See http://docs.recurly.com/api/invoices
+        // See https://dev.recurly.com/docs/list-invoices
         final String invoicesData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
                                     + "<invoices type=\"array\">\n"
                                     + "  <invoice href=\"https://api.recurly.com/v2/invoices/e3f0a9e084a2468480d00ee61b090d4d\">\n"

--- a/src/test/java/com/ning/billing/recurly/model/TestModelBase.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestModelBase.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/test/java/com/ning/billing/recurly/model/TestPlan.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestPlan.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/test/java/com/ning/billing/recurly/model/TestPlan.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestPlan.java
@@ -25,7 +25,7 @@ public class TestPlan extends TestModelBase {
 
     @Test(groups = "fast")
     public void testDeserializationWithAmounts() throws Exception {
-        // See http://docs.recurly.com/api/plans
+        // See https://dev.recurly.com/docs/list-plans
         final String planData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                                 "<plan href=\"https://api.recurly.com/v2/plans/gold\">\n" +
                                 "  <add_ons href=\"https://api.recurly.com/v2/plans/gold/add_ons\"/>\n" +
@@ -78,7 +78,7 @@ public class TestPlan extends TestModelBase {
 
     @Test(groups = "fast")
     public void testDeserializationWithoutAmounts() throws Exception {
-        // See http://docs.recurly.com/api/plans
+        // See https://dev.recurly.com/docs/list-plans
         final String planData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                                 "<plan href=\"https://api.recurly.com/v2/plans/gold\">\n" +
                                 "  <add_ons href=\"https://api.recurly.com/v2/plans/gold/add_ons\"/>\n" +

--- a/src/test/java/com/ning/billing/recurly/model/TestPlans.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestPlans.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/test/java/com/ning/billing/recurly/model/TestPlans.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestPlans.java
@@ -25,7 +25,7 @@ public class TestPlans extends TestModelBase {
 
     @Test(groups = "fast")
     public void testDeserialization() throws Exception {
-        // See http://docs.recurly.com/api/plans
+        // See https://dev.recurly.com/docs/list-plans
         final String plansData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                                  "<plans type=\"array\">\n" +
                                  "  <plan href=\"https://api.recurly.com/v2/plans/gold\">\n" +

--- a/src/test/java/com/ning/billing/recurly/model/TestRecurlyObject.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestRecurlyObject.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/test/java/com/ning/billing/recurly/model/TestRedemption.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestRedemption.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/test/java/com/ning/billing/recurly/model/TestRedemption.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestRedemption.java
@@ -25,7 +25,7 @@ public class TestRedemption extends TestModelBase {
 
     @Test(groups = "fast")
     public void testDeserialization() throws Exception {
-        // See https://docs.recurly.com/api/coupons/coupon-redemption
+        // See https://dev.recurly.com/docs/lookup-a-coupon-redemption-on-an-account
         final String redemptionData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                 "<redemption href=\"https://your-subdomain.recurly.com/v2/accounts/1/redemption\">\n" +
                 "  <coupon href=\"https://your-subdomain.recurly.com/v2/coupons/special\"/>\n" +

--- a/src/test/java/com/ning/billing/recurly/model/TestSubscription.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestSubscription.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/test/java/com/ning/billing/recurly/model/TestSubscription.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestSubscription.java
@@ -27,7 +27,7 @@ public class TestSubscription extends TestModelBase {
 
     @Test(groups = "fast")
     public void testDeserialization() throws Exception {
-        // See http://docs.recurly.com/api/subscriptions
+        // See https://dev.recurly.com/docs/list-subscriptions
         final String subscriptionData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                                         "<subscription href=\"https://api.recurly.com/v2/subscriptions/44f83d7cba354d5b84812419f923ea96\">\n" +
                                         "  <account href=\"https://api.recurly.com/v2/accounts/1\"/>\n" +
@@ -77,7 +77,7 @@ public class TestSubscription extends TestModelBase {
 
     @Test(groups = "fast")
     public void testDeserializationWithAddons() throws Exception {
-        // See http://docs.recurly.com/api/subscriptions/subscription-add-ons
+        // See https://dev.recurly.com/docs/subscription-add-ons
         final String subscriptionData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                                         "<subscription href=\"https://api.recurly.com/v2/subscriptions/44f83d7cba354d5b84812419f923ea96\">\n" +
                                         "  <account href=\"https://api.recurly.com/v2/accounts/1\"/>\n" +

--- a/src/test/java/com/ning/billing/recurly/model/TestSubscriptionUpdate.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestSubscriptionUpdate.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/test/java/com/ning/billing/recurly/model/TestSubscriptionUpdate.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestSubscriptionUpdate.java
@@ -24,7 +24,7 @@ public class TestSubscriptionUpdate extends TestModelBase {
 
     @Test(groups = "fast")
     public void testDeserialization() throws Exception {
-        // See http://docs.recurly.com/api/subscriptions
+        // See https://dev.recurly.com/docs/list-subscriptions
         final String subscriptionData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                                         "<subscription>\n" +
                                         "  <timeframe>now</timeframe>\n" +

--- a/src/test/java/com/ning/billing/recurly/model/TestSubscriptions.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestSubscriptions.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/test/java/com/ning/billing/recurly/model/TestSubscriptions.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestSubscriptions.java
@@ -24,7 +24,7 @@ public class TestSubscriptions extends TestModelBase {
 
     @Test(groups = "fast")
     public void testDeserialization() throws Exception {
-        // See http://docs.recurly.com/api/subscriptions
+        // See https://dev.recurly.com/docs/list-subscriptions
         final String subscriptionsData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                                          "<subscriptions type=\"array\">\n" +
                                          "  <subscription href=\"https://your-subdomain.recurly.com/v2/subscriptions/44f83d7cba354d5b84812419f923ea96\">\n" +

--- a/src/test/java/com/ning/billing/recurly/model/TestXmlMapper.java
+++ b/src/test/java/com/ning/billing/recurly/model/TestXmlMapper.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/test/java/com/ning/billing/recurly/model/push/TestNotification.java
+++ b/src/test/java/com/ning/billing/recurly/model/push/TestNotification.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/test/java/com/ning/billing/recurly/model/push/TestNotification.java
+++ b/src/test/java/com/ning/billing/recurly/model/push/TestNotification.java
@@ -47,7 +47,7 @@ import com.ning.billing.recurly.model.push.subscription.UpdatedSubscriptionNotif
 
 import com.google.common.base.CaseFormat;
 
-// See http://docs.recurly.com/api/push-notifications
+// See https://recurly.readme.io/v2.0/page/webhooks
 public class TestNotification extends TestModelBase {
 
     private static final Logger log = LoggerFactory.getLogger(TestNotification.class);

--- a/src/test/java/com/ning/billing/recurly/model/push/TestNotification.java
+++ b/src/test/java/com/ning/billing/recurly/model/push/TestNotification.java
@@ -34,7 +34,7 @@ import com.ning.billing.recurly.model.push.payment.PaymentNotification;
 import com.ning.billing.recurly.model.push.payment.PushTransaction;
 import com.ning.billing.recurly.model.push.payment.SuccessfulPaymentNotification;
 import com.ning.billing.recurly.model.push.payment.SuccessfulRefundNotification;
-import com.ning.billing.recurly.model.push.payment.VoidedPaymentNotification;
+import com.ning.billing.recurly.model.push.payment.VoidPaymentNotification;
 import com.ning.billing.recurly.model.push.subscription.CanceledSubscriptionNotification;
 import com.ning.billing.recurly.model.push.subscription.ExpiredSubscriptionNotification;
 import com.ning.billing.recurly.model.push.subscription.NewSubscriptionNotification;
@@ -262,8 +262,8 @@ public class TestNotification extends TestModelBase {
     }
 
     @Test(groups = "fast")
-    public void testVoidedPaymentNotification() {
-        deserialize(VoidedPaymentNotification.class);
+    public void testVoidPaymentNotification() {
+        deserialize(VoidPaymentNotification.class);
     }
 
     @Test(groups = "fast")

--- a/src/test/java/com/ning/billing/recurly/model/push/TestVoidNotification.java
+++ b/src/test/java/com/ning/billing/recurly/model/push/TestVoidNotification.java
@@ -1,7 +1,8 @@
 /*
- * Copyright 2010-2013 Ning, Inc.
+ * Copyright 2010-2014 Ning, Inc.
+ * Copyright 2014-2015 The Billing Project, LLC
  *
- * Ning licenses this file to you under the Apache License, version 2.0
+ * The Billing Project licenses this file to you under the Apache License, version 2.0
  * (the "License"); you may not use this file except in compliance with the
  * License.  You may obtain a copy of the License at:
  *

--- a/src/test/java/com/ning/billing/recurly/model/push/TestVoidNotification.java
+++ b/src/test/java/com/ning/billing/recurly/model/push/TestVoidNotification.java
@@ -22,7 +22,7 @@ import com.ning.billing.recurly.model.push.payment.VoidPaymentNotification;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-// See http://docs.recurly.com/api/push-notifications
+// See https://recurly.readme.io/v2.0/page/webhooks
 public class TestVoidNotification extends TestModelBase {
 
     @Test(groups = "fast")

--- a/src/test/java/com/ning/billing/recurly/model/push/TestVoidNotification.java
+++ b/src/test/java/com/ning/billing/recurly/model/push/TestVoidNotification.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2010-2013 Ning, Inc.
+ *
+ * Ning licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.ning.billing.recurly.model.push;
+
+import com.ning.billing.recurly.model.TestModelBase;
+import com.ning.billing.recurly.model.push.payment.VoidPaymentNotification;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+// See http://docs.recurly.com/api/push-notifications
+public class TestVoidNotification extends TestModelBase {
+
+    @Test(groups = "fast")
+    public void testDeserialization() throws Exception {
+        final String voidData = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                                "<void_payment_notification>\n" +
+                                "  <account>\n" +
+                                "    <account_code>1</account_code>\n" +
+                                "    <username nil=\"true\"></username>\n" +
+                                "    <email>verena@example.com</email>\n" +
+                                "    <first_name>Verena</first_name>\n" +
+                                "    <last_name>Example</last_name>\n" +
+                                "    <company_name nil=\"true\"></company_name>\n" +
+                                "  </account>\n" +
+                                "  <transaction>\n" +
+                                "    <id>4997ace0f57341adb3e857f9f7d15de8</id>\n" +
+                                "    <invoice_id>ffc64d71d4b5404e93f13aac9c63b007</invoice_id>\n" +
+                                "    <invoice_number_prefix></invoice_number_prefix>\n" +
+                                "    <invoice_number type=\"integer\">2059</invoice_number>\n" +
+                                "    <subscription_id>1974a098jhlkjasdfljkha898326881c</subscription_id>\n" +
+                                "    <action>purchase</action>\n" +
+                                "    <date type=\"datetime\">2010-10-05T23:00:50Z</date>\n" +
+                                "    <amount_in_cents type=\"integer\">235</amount_in_cents>\n" +
+                                "    <status>void</status>\n" +
+                                "    <message>Test Gateway: Successful test transaction</message>\n" +
+                                "    <reference></reference>\n" +
+                                "    <source>subscription</source>\n" +
+                                "    <cvv_result code=\"M\">Match</cvv_result>\n" +
+                                "    <avs_result code=\"D\">Street address and postal code match.</avs_result>\n" +
+                                "    <avs_result_street></avs_result_street>\n" +
+                                "    <avs_result_postal></avs_result_postal>\n" +
+                                "    <test type=\"boolean\">true</test>\n" +
+                                "    <voidable type=\"boolean\">false</voidable>\n" +
+                                "    <refundable type=\"boolean\">false</refundable>\n" +
+                                "  </transaction>\n" +
+                                "</void_payment_notification>";
+
+        Notification.Type detected = Notification.detect(voidData);
+        Assert.assertEquals(detected.getJavaType(), VoidPaymentNotification.class);
+
+        final VoidPaymentNotification voidPaymentNotification = Notification.read(voidData, VoidPaymentNotification.class);
+        Assert.assertNotNull(voidPaymentNotification);
+    }
+
+}


### PR DESCRIPTION
Upgrading to Jackson 2.5 or higher causes recurly api calls to stop working. An example of a failed create subscription call:

```
<?xml version="1.0" encoding="UTF-8"?>
<error>
  <symbol>invalid_xml</symbol>
  <description>The provided XML was invalid.</description>
  <details>Unacceptable tag &lt;state&gt;</details>
</error>
```

This is the actual xml generated by recurly java library:

```
<subscription><unit_amount_in_cents/><quantity/><plan_code>full</plan_code><account><address/><account_code>xxxxxxxxxx</account_code><state/><username/><email/><first_name/><last_name/><company_name/><accept_language/><hosted_login_token/><created_at/><billing_info><account/><first_name/><last_name/><company/><address1/><address2/><city/><state/><zip/><country/><phone/><vat_number/><ip_address/><ip_address_country/><card_type/><year/><month/><first_six/><last_four/><number/><verification_value/><token_id>xyyxyxxyxyxy</token_id></billing_info></account><invoice/><plan/><uuid/><state/><currency>USD</currency><activated_at/><canceled_at/><expires_at/><current_period_started_at/><current_period_ends_at/><trial_started_at/><trial_ends_at/><pending_subscription/><starts_at/><collection_method/><net_terms/><coupon_code/><po_number/><terms_and_conditions/><customer_notes/><first_renewal_date/><bulk/></subscription>
```

Prior to the upgrade the actual xml doesn't include empty or null values like the example below:

```
<subscription><plan_code>plan</plan_code><account><account_code>xxxxxxxxxx</account_code><billing_info><token_id>xyyxyxxyxyxy</token_id></billing_info></account><currency>USD</currency></subscription>
```

Adding the below line to the RecurlyObject.java in newXmlMapper() method, fixes the problem.

```
xmlMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY); 
```
